### PR TITLE
feat: add support for the navigator

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,35 @@ module('Scenario Name', function (hooks) {
 });
 ```
 
+#### navigator
+
+```js
+// An example test from ember-jsqr's tests
+module('Scenario Name', function (hooks) {
+  setupApplicationTest(hooks);
+  setupBrowserFakes(hooks, {
+    navigator: {
+      mediaDevices: {
+        getUserMedia: () => ({ getTracks: () => [] }),
+      },
+    },
+  });
+
+  test('the camera can be turned on and then off', async function (assert) {
+    let selector = '[data-test-single-camera-demo] button';
+
+    await visit('/docs/single-camera');
+    await click(selector);
+
+    assert.dom(selector).hasText('Stop Camera', 'the camera is now on');
+
+    await click(selector);
+
+    assert.dom(selector).hasText('Start Camera', 'the camera has been turned off');
+  });
+});
+```
+
 #### document
 
 ```js

--- a/addon-test-support/-private/-helpers.ts
+++ b/addon-test-support/-private/-helpers.ts
@@ -2,6 +2,8 @@ import Service from '@ember/service';
 
 import { proxyService } from 'ember-browser-services/utils/proxy-service';
 
+import type { Class } from 'ember-browser-services/types';
+
 // this usage of any is correct, because it literally could be *any*thing
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type UnknownObject = Record<string, any>;
@@ -19,4 +21,26 @@ export function maybeMake<DefaultType extends typeof Service, TestClass extends 
   }
 
   return defaultImplementation;
+}
+
+export function testableVersionOf<
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  Real extends object,
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  TestInstance extends object,
+  TestClass extends Class<TestInstance>
+>(real: Real, Klass: TestClass) {
+  let overrides = new Klass();
+
+  let proxied = new Proxy(overrides, {
+    get(target, propName, receiver) {
+      if (propName in target) {
+        return Reflect.get(target, propName, receiver);
+      }
+
+      return Reflect.get(real, propName);
+    },
+  });
+
+  return proxied;
 }

--- a/addon-test-support/-private/navigator.ts
+++ b/addon-test-support/-private/navigator.ts
@@ -1,0 +1,33 @@
+import RSVP from 'rsvp';
+import { proxyService } from 'ember-browser-services/utils/proxy-service';
+import { testableVersionOf } from './-helpers';
+
+export type TestNavigator = typeof fakeNavigator;
+
+type UserInteractions<Source> = Partial<Record<keyof Source, RSVP.Deferred<unknown>>>;
+
+export const fakeMediaDevices = testableVersionOf(
+  navigator.mediaDevices,
+  class TestMediaDevices {
+    interactions: UserInteractions<MediaDevices> = {};
+
+    getUserMedia(_options: Parameters<typeof navigator.mediaDevices.getUserMedia>) {
+      let deferred = RSVP.defer();
+
+      this.interactions.getUserMedia = deferred;
+
+      return deferred.promise;
+    }
+  },
+);
+
+export const fakeNavigator = testableVersionOf(
+  Navigator,
+  class TestClass {
+    get mediaDevices() {
+      return fakeMediaDevices;
+    }
+  },
+);
+
+export const FakeNavigatorService = proxyService(fakeNavigator);

--- a/addon-test-support/-private/navigator.ts
+++ b/addon-test-support/-private/navigator.ts
@@ -1,23 +1,12 @@
-import RSVP from 'rsvp';
 import { proxyService } from 'ember-browser-services/utils/proxy-service';
 import { testableVersionOf } from './-helpers';
 
 export type TestNavigator = typeof fakeNavigator;
 
-type UserInteractions<Source> = Partial<Record<keyof Source, RSVP.Deferred<unknown>>>;
-
 export const fakeMediaDevices = testableVersionOf(
   navigator.mediaDevices,
   class TestMediaDevices {
-    interactions: UserInteractions<MediaDevices> = {};
-
-    getUserMedia(_options: Parameters<typeof navigator.mediaDevices.getUserMedia>) {
-      let deferred = RSVP.defer();
-
-      this.interactions.getUserMedia = deferred;
-
-      return deferred.promise;
-    }
+    // overrides deliberately left empty
   },
 );
 

--- a/addon-test-support/index.ts
+++ b/addon-test-support/index.ts
@@ -1,6 +1,7 @@
 import { FakeDocumentService, TestDocument } from './-private/document';
 import { FakeLocalStorageService } from './-private/local-storage';
 import { FakeWindowService, TestWindow } from './-private/window';
+import { FakeNavigatorService } from './-private/navigator';
 import { maybeMake } from './-private/-helpers';
 
 import type Service from '@ember/service';
@@ -10,6 +11,7 @@ type Fakes = {
   window?: boolean | TestWindow | typeof Service;
   localStorage?: boolean;
   document?: boolean | TestDocument | typeof Service;
+  navigator?: boolean;
 };
 
 export function setupBrowserFakes(hooks: NestedHooks, options: Fakes): void {
@@ -27,6 +29,10 @@ export function setupBrowserFakes(hooks: NestedHooks, options: Fakes): void {
 
     if (options.localStorage) {
       this.owner.register('service:browser/local-storage', FakeLocalStorageService);
+    }
+
+    if (options.navigator) {
+      this.owner.register('service:browser/navigator', FakeNavigatorService);
     }
   });
 }

--- a/addon-test-support/index.ts
+++ b/addon-test-support/index.ts
@@ -1,7 +1,7 @@
 import { FakeDocumentService, TestDocument } from './-private/document';
 import { FakeLocalStorageService } from './-private/local-storage';
 import { FakeWindowService, TestWindow } from './-private/window';
-import { FakeNavigatorService } from './-private/navigator';
+import { FakeNavigatorService, TestNavigator } from './-private/navigator';
 import { maybeMake } from './-private/-helpers';
 
 import type Service from '@ember/service';
@@ -11,7 +11,7 @@ type Fakes = {
   window?: boolean | TestWindow | typeof Service;
   localStorage?: boolean;
   document?: boolean | TestDocument | typeof Service;
-  navigator?: boolean;
+  navigator?: boolean | TestNavigator;
 };
 
 export function setupBrowserFakes(hooks: NestedHooks, options: Fakes): void {
@@ -32,7 +32,10 @@ export function setupBrowserFakes(hooks: NestedHooks, options: Fakes): void {
     }
 
     if (options.navigator) {
-      this.owner.register('service:browser/navigator', FakeNavigatorService);
+      this.owner.register(
+        'service:browser/navigator',
+        maybeMake(options.navigator, FakeNavigatorService),
+      );
     }
   });
 }

--- a/addon/services/browser/navigator.ts
+++ b/addon/services/browser/navigator.ts
@@ -1,0 +1,21 @@
+import '@ember/service';
+
+import { proxyService } from 'ember-browser-services/utils/proxy-service';
+
+const NavigatorProxyService = proxyService(navigator);
+
+/**
+ * In order to have thorough testing, we should only interact with the navigator
+ * (and other browser APIs) via a service.
+ *
+ * We can control, mock, and override the services, but we can't do so with
+ * the browser APIs.
+ *
+ */
+export default NavigatorProxyService;
+
+declare module '@ember/service' {
+  interface Registry {
+    'browser/navigator': typeof NavigatorProxyService;
+  }
+}

--- a/addon/types.ts
+++ b/addon/types.ts
@@ -5,3 +5,7 @@ import type { default as _WindowService } from './services/browser/window';
 export type WindowService = typeof _WindowService;
 export type DocumentService = typeof _DocumentService;
 export type LocalStorageService = typeof _LocalStorageService;
+
+export interface Class<T> {
+  new (...args: unknown[]): T;
+}

--- a/addon/types.ts
+++ b/addon/types.ts
@@ -1,10 +1,12 @@
 import type { default as _DocumentService } from './services/browser/document';
 import type { default as _LocalStorageService } from './services/browser/local-storage';
+import type { default as _NavigatorService } from './services/browser/navigator';
 import type { default as _WindowService } from './services/browser/window';
 
 export type WindowService = typeof _WindowService;
 export type DocumentService = typeof _DocumentService;
 export type LocalStorageService = typeof _LocalStorageService;
+export type NavigatorService = typeof _NavigatorService;
 
 export interface Class<T> {
   new (...args: unknown[]): T;

--- a/addon/utils/proxy-service.ts
+++ b/addon/utils/proxy-service.ts
@@ -1,8 +1,6 @@
 import Service from '@ember/service';
 
-interface Class<T> {
-  new (...args: unknown[]): T;
-}
+import type { Class } from 'ember-browser-services/types';
 
 /**
  * Allows Services to behave as Proxy objects for real objects, such as

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = {
   name: require('./package').name,
 
   // enable file-watching / live-reload
-  // isDevelopingAddon: () => true,
+  isDevelopingAddon: () => true,
 
   options: {
     'ember-cli-babel': {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = {
   name: require('./package').name,
 
   // enable file-watching / live-reload
-  isDevelopingAddon: () => true,
+  // isDevelopingAddon: () => true,
 
   options: {
     'ember-cli-babel': {

--- a/tests/unit/services/browser/navigator-test.ts
+++ b/tests/unit/services/browser/navigator-test.ts
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { setupBrowserFakes } from 'ember-browser-services/test-support';
+import { setupTest } from 'ember-qunit';
+
+module('Service | browser/navigator', function (hooks) {
+  setupTest(hooks);
+  setupBrowserFakes(hooks, { navigator: true });
+
+  module('mediaDevices', function () {
+    module('getUserMedia', function () {
+      test('can be manually resolved', async function (assert) {
+        let service = this.owner.lookup('service:browser/navigator');
+        let request = service.mediaDevices.getUserMedia();
+
+        service.mediaDevices.interactions.getUserMedia.resolve('my custom media stream');
+
+        let stream = await request;
+
+        assert.equal(stream, 'my custom media stream');
+      });
+
+      test('can be rejected', async function (assert) {
+        let service = this.owner.lookup('service:browser/navigator');
+        let request = service.mediaDevices.getUserMedia();
+
+        service.mediaDevices.interactions.getUserMedia.reject('no camera access!');
+
+        await assert.rejects(request, 'no camera access');
+      });
+    });
+  });
+});

--- a/tests/unit/services/browser/navigator-test.ts
+++ b/tests/unit/services/browser/navigator-test.ts
@@ -1,18 +1,50 @@
 import { module, test } from 'qunit';
-import { setupBrowserFakes } from 'ember-browser-services/test-support';
+import RSVP from 'rsvp';
 import { setupTest } from 'ember-qunit';
+
+import { setupBrowserFakes } from 'ember-browser-services/test-support';
+
+import type ApplicationInstance from '@ember/application/instance';
+import type { NavigatorService } from 'ember-browser-services/types';
+
+function getNavigatorService(owner: ApplicationInstance) {
+  return owner.lookup('service:browser/navigator') as NavigatorService;
+}
 
 module('Service | browser/navigator', function (hooks) {
   setupTest(hooks);
-  setupBrowserFakes(hooks, { navigator: true });
 
-  module('mediaDevices', function () {
-    module('getUserMedia', function () {
+  module('for config: true', function (hooks) {
+    setupBrowserFakes(hooks, { navigator: true });
+
+    test('APIs fallback to browser APIs', function (assert) {
+      let service = getNavigatorService(this.owner);
+
+      assert.equal(service.mediaDevices.getUserMedia, navigator.mediaDevices.getUserMedia);
+    });
+  });
+
+  module('for config: object override', function () {
+    module('mediaDevices.getUserMedia', function (hooks) {
+      let deferred: RSVP.Deferred<string>;
+
+      setupBrowserFakes(hooks, {
+        navigator: {
+          mediaDevices: {
+            getUserMedia() {
+              deferred = RSVP.defer();
+
+              return deferred.promise;
+            },
+          },
+        },
+      });
+
       test('can be manually resolved', async function (assert) {
-        let service = this.owner.lookup('service:browser/navigator');
+        let service = getNavigatorService(this.owner);
         let request = service.mediaDevices.getUserMedia();
 
-        service.mediaDevices.interactions.getUserMedia.resolve('my custom media stream');
+        deferred.resolve('my custom media stream');
 
         let stream = await request;
 
@@ -20,10 +52,10 @@ module('Service | browser/navigator', function (hooks) {
       });
 
       test('can be rejected', async function (assert) {
-        let service = this.owner.lookup('service:browser/navigator');
+        let service = getNavigatorService(this.owner);
         let request = service.mediaDevices.getUserMedia();
 
-        service.mediaDevices.interactions.getUserMedia.reject('no camera access!');
+        deferred.reject('no camera access!');
 
         await assert.rejects(request, 'no camera access');
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5243,7 +5243,7 @@ debug@~4.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -8172,7 +8172,7 @@ import-lazy@^2.1.0:
   resolved "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
   integrity sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -9333,11 +9333,6 @@ lodash._baseflatten@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -9346,15 +9341,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*, lodash._bindcallback@^3.0.0:
+lodash._bindcallback@^3.0.0:
   version "3.0.1"
   resolved "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
   integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
 
 lodash._createassigner@^3.0.0:
   version "3.1.1"
@@ -9365,19 +9355,12 @@ lodash._createassigner@^3.0.0:
     lodash._isiterateecall "^3.0.0"
     lodash.restparam "^3.0.0"
 
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
 
-lodash._getnative@*, lodash._getnative@^3.0.0:
+lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
   integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
@@ -9510,7 +9493,7 @@ lodash.omit@^4.1.0:
   resolved "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
   integrity sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=
 
-lodash.restparam@*, lodash.restparam@^3.0.0:
+lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
   integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=


### PR DESCRIPTION
The need for this comes from a couple projects:
 - https://github.com/NullVoxPopuli/emberclear/blob/19f720b7d188553a8534b0173f3bbb5a890a65c5/client/web/emberclear/tests/integration/pods/components/q-r-scanner/component-test.ts#L18
 - https://github.com/NullVoxPopuli/ember-jsqr/blob/94e44709fae3217dc9be9f8aafde53e0ed1a42c0/tests/dummy/app/components/demo/multiple-cameras.ts#L37
Wanting to test behavior around media devices without destroying and (hopefully) restoring the real implementation.

also, more generally, I've added a pattern for falling back to the the browser functionality,
rather than requiring everything to implemented up front, which will help address #15 

Example usage of the behavior provided by the work in this PR: https://github.com/NullVoxPopuli/ember-jsqr/pull/185/files#diff-03f121aa4cd6c61469e4c704a56b2fc3eb13d4d24094fe1d80c408228e941f29R11