### PR TITLE
Add fetch example & test

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,13 +125,25 @@ import { setupBrowserFakes } from 'ember-browser-services/test-support';
 
 module('Scenario Name', function (hooks) {
   setupBrowserFakes(hooks, {
-    window: { location: { href: 'https://crowdstrike.com' } },
+    window: {
+      location: { href: 'https://crowdstrike.com' },
+      fetch: async (url) => ({ url })
+    },
   });
 
   test('is at crowdstrike.com', function (assert) {
     let service = this.owner.lookup('service:browser/window');
 
     assert.equal(service.location.href, 'https://crowdstrike.com'); // => succeeds
+  });
+
+  test('fetches from crowdstrike.com', async function (assert) {
+    let service = this.owner.lookup('service:browser/window');
+    let urlPath = 'crowdstrike.com';
+
+    let { url: urlUsed } = await service.fetch(urlPath);
+
+    assert.equal(urlUsed, urlPath);
   });
 });
 ```


### PR DESCRIPTION
This is one of the situations I’ve used the most with `ember-browser-services` but I didn’t see it reflected on the documentation… So I whipped up an example and corresponding test to make it clearer for other users.

I ran into an interesting situation on the test, where the function was being bound and I had to think a bit outside the box. Let me know what you think!