### PR TITLE
chore(internal): update CI -- add TS 4.8 and 4.9 to CI

### DIFF
--- a/.github/actions/assert-build/action.yml
+++ b/.github/actions/assert-build/action.yml
@@ -1,0 +1,39 @@
+name: Build and Assert Assets Exists
+description: Build the package and assert that file contents exist as we expect
+runs:
+  using: "composite"
+  steps:
+  - name: Build and Assert Output
+    shell: bash
+    run: |-
+      echo '
+        target: ${{ env.dist }}
+        setup:
+          run: pnpm build:js
+          cwd: ./ember-browser-services
+        expect: |
+          index.js
+          index.js.map
+          index.d.ts
+          index.d.ts.map
+          services/browser/document.d.ts
+          services/browser/document.js
+          services/browser/document.js.map
+          services/browser/local-storage.d.ts
+          services/browser/local-storage.js
+          services/browser/local-storage.js.map
+          services/browser/navigator.d.ts
+          services/browser/navigator.js
+          services/browser/navigator.js.map
+          test-support/index.js
+          test-support/index.js.map
+          test-support/index.d.ts
+          
+      ' >> assert-contents.config.yml
+      npx assert-folder-contents
+
+  - name: Upload dist assets to cache
+    uses: actions/upload-artifact@v3
+    with:
+      name: dist
+      path: ${{ env.dist }}

--- a/.github/actions/download-built-package/action.yml
+++ b/.github/actions/download-built-package/action.yml
@@ -1,0 +1,10 @@
+name: Download built package from cache
+description: Download built package from cache
+runs:
+  using: "composite"
+  steps:
+  - name: Download built package from cache
+    uses: actions/download-artifact@v3
+    with:
+      name: dist
+      path: ${{ env.dist }}

--- a/.github/actions/pnpm/action.yml
+++ b/.github/actions/pnpm/action.yml
@@ -1,0 +1,14 @@
+name: Setup node and pnpm
+description: Setup node and install dependencies using pnpm
+runs:
+  using: "composite"
+  steps:
+    - uses: pnpm/action-setup@v2.2.2
+      with:
+        version: 7
+    - uses: actions/setup-node@v3
+      with:
+        cache: 'pnpm'
+    - name: 'Install dependencies'
+      shell: 'bash'
+      run: pnpm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,39 +1,33 @@
 name: CI
-"on":
-  pull_request: null
+
+on:
   push:
     branches:
       - main
-  schedule:
-    - cron: "0 3 * * 0 "
+      - master
+  pull_request: {}
+
+concurrency:
+   group: ci-${{ github.head_ref || github.ref }}
+   cancel-in-progress: true
+
 env:
   CI: true
   dist: ember-browser-services/dist
+
 jobs:
   install_dependencies:
-    name: Install Dependencies
-    timeout-minutes: 5
+    name: Install
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: volta-cli/action@v1
-      - name: Cache pnpm modules
-        uses: actions/cache@v3
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-
-      - uses: pnpm/action-setup@v2.2.2
-        with:
-          version: 7.1.2
-      - name: Install Dependencies
-        run: pnpm install
+      - uses: ./.github/actions/pnpm
+
+
   eslint:
-    name: ESLint
-    needs:
-      - install_dependencies
-    timeout-minutes: 5
+    name: ESLint {{ matrix.path }}
     runs-on: ubuntu-latest
+    needs: [install_dependencies]
     strategy:
       fail-fast: true
       matrix:
@@ -42,141 +36,105 @@ jobs:
           - ./test-app
     steps:
       - uses: actions/checkout@v3
-      - uses: volta-cli/action@v1
-      - name: Cache pnpm modules
-        uses: actions/cache@v3
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-
-      - uses: pnpm/action-setup@v2.2.2
-        with:
-          version: 7.1.2
-      - name: Install Dependencies
-        run: pnpm install
-      - name: ESLint
-        run: cd ${{ matrix.path }} && pnpm run lint:js
+      - uses: ./.github/actions/pnpm
+      - name: Lint
+        run: pnpm eslint .
+        working-directory: ${{ matrix.path }}
+
+
+
+
+
   commits:
     name: Commit Messages
-    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: volta-cli/action@v1
-      - uses: wagoid/commitlint-github-action@v5.0.2
+      - uses: ./.github/actions/pnpm
+      - uses: wagoid/commitlint-github-action@v5.2.0
+        with:
+          configFile: 'commitlint.config.cjs'
+
+
   build:
     name: Build Tests
-    needs:
-      - install_dependencies
+    needs: [install_dependencies]
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: volta-cli/action@v1
-      - name: Cache pnpm modules
-        uses: actions/cache@v3
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-
-      - uses: pnpm/action-setup@v2.2.2
-        with:
-          version: 7.1.2
-      - name: Install Dependencies
-        run: pnpm install
-      - name: Build and Assert Output
-        run: |-
-          echo 'target: ember-browser-services/dist
-          setup:
-            run: pnpm build:js
-            cwd: ./ember-browser-services
-          expect: |
-            index.js
-            index.js.map
-            index.d.ts
-            index.d.ts.map
-            services/browser/document.d.ts
-            services/browser/document.js
-            services/browser/document.js.map
-            services/browser/local-storage.d.ts
-            services/browser/local-storage.js
-            services/browser/local-storage.js.map
-            services/browser/navigator.d.ts
-            services/browser/navigator.js
-            services/browser/navigator.js.map
-            test-support/index.js
-            test-support/index.js.map
-            test-support/index.d.ts
-          ' >> assert-contents.config.yml
-                        npx assert-folder-contents
-      - uses: actions/upload-artifact@v3
-        with:
-          name: dist
-          path: ${{ env.dist }}
-  tests:
-    name: Default Tests
-    timeout-minutes: 5
+      - uses: ./.github/actions/pnpm
+      - uses: ./.github/actions/assert-build
+
+
+  typecheck:
+    name: '${{ matrix.typescript-scenario }}'
     runs-on: ubuntu-latest
-    needs:
-      - build
-    steps:
-      - uses: actions/checkout@v3
-      - uses: volta-cli/action@v1
-      - name: Cache pnpm modules
-        uses: actions/cache@v3
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-
-      - uses: pnpm/action-setup@v2.2.2
-        with:
-          version: 7.1.2
-      - name: Install Dependencies
-        run: pnpm install
-      - name: Download built package from cache
-        uses: actions/download-artifact@v3
-        with:
-          name: dist
-          path: ${{ env.dist }}
-      - run: pnpm --filter test-app run test:ember
-  floating-deps-tests:
-    name: Floating Deps Test
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    needs:
-      - build
-    steps:
-      - uses: actions/checkout@v3
-      - uses: volta-cli/action@v1
-      - name: Cache pnpm modules
-        uses: actions/cache@v3
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-
-      - uses: pnpm/action-setup@v2.2.2
-        with:
-          version: 7.1.2
-      - name: Install Dependencies (without lockfile)
-        run: rm pnpm-lock.yaml && pnpm install
-      - name: Download built package from cache
-        uses: actions/download-artifact@v3
-        with:
-          name: dist
-          path: ${{ env.dist }}
-      - run: pnpm --filter test-app run test:ember
-  try-scenarios:
-    name: ${{ matrix.ember-try-scenario }}
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    needs:
-      - tests
+    timeout-minutes: 2
+    needs: [build]
+    continue-on-error: true
     strategy:
       fail-fast: true
       matrix:
-        ember-try-scenario:
+        typescript-scenario:
+          - typescript@4.5
+          - typescript@4.6
+          - typescript@4.7
+          - typescript@4.8
+          - typescript@4.9
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/pnpm
+      - uses: ./.github/actions/download-built-package
+      - name: 'Change TS to ${{ matrix.typescript-scenario }}'
+        run: 'pnpm add --save-dev ${{ matrix.typescript-scenario}}'
+        working-directory: ./test-app
+      - name: 'Type checking'
+        run: |
+          pnpm --filter test-app exec tsc -v;
+          pnpm --filter test-app exec tsc --build;
+
+  
+
+
+  default_tests:
+    name: Default Tests
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/pnpm
+      - uses: ./.github/actions/download-built-package
+      - run: pnpm --filter test-app test:ember
+
+  floating_tests:
+    name: Floating Deps Test
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/pnpm
+      - name: Install Dependencies (without lockfile)
+        run: rm pnpm-lock.yaml && pnpm install
+      - uses: ./.github/actions/download-built-package
+      - run: pnpm --filter test-app test:ember
+
+
+  try_scenarios:
+    name: ${{ matrix.try-scenario }}
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    needs: [default_tests]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        try-scenario:
           - ember-lts-3.8
           - ember-lts-3.12
           - ember-lts-3.16
@@ -190,104 +148,43 @@ jobs:
           - ember-canary
           - embroider-safe
           - embroider-optimized
+
     steps:
       - uses: actions/checkout@v3
-      - uses: volta-cli/action@v1
-      - name: Cache pnpm modules
-        uses: actions/cache@v3
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-
-      - uses: pnpm/action-setup@v2.2.2
-        with:
-          version: 7.1.2
-      - name: Install Dependencies
-        run: pnpm install
-      - name: Download built package from cache
-        uses: actions/download-artifact@v3
-        with:
-          name: dist
-          path: ${{ env.dist }}
-      - name: test
+      - uses: ./.github/actions/pnpm
+      - uses: ./.github/actions/download-built-package
+      - name: Run Tests
         working-directory: ./test-app
         run: >-
-          node_modules/.bin/ember try:one ${{ matrix.ember-try-scenario }}
+          node_modules/.bin/ember try:one ${{ matrix.try-scenario }}
           --skip-cleanup
-  typescript-compatibility:
-    name: ${{ matrix.typescript-scenario }}
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    needs:
-      - build
-    strategy:
-      fail-fast: true
-      matrix:
-        typescript-scenario:
-          - typescript@4.5
-          - typescript@4.6
-          - typescript@4.7
-    steps:
-      - uses: actions/checkout@v3
-      - uses: volta-cli/action@v1
-      - name: Cache pnpm modules
-        uses: actions/cache@v3
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-
-      - uses: pnpm/action-setup@v2.2.2
-        with:
-          version: 7.1.2
-      - name: Install Dependencies (without lockfile)
-        run: rm pnpm-lock.yaml && pnpm install
-      - name: Download built package from cache
-        uses: actions/download-artifact@v3
-        with:
-          name: dist
-          path: ${{ env.dist }}
-      - name: Update TS Version
-        run: pnpm add --save-dev ${{ matrix.typescript-scenario }}
-        working-directory: ./test-app
-      - name: Type checking
-        run: |-
-          pnpm --filter test-app exec tsc -v;
-          pnpm --filter test-app exec tsc --build
+
+
+
+
   release:
     name: Release
     timeout-minutes: 5
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     needs:
-      - tests
-      - typescript-compatibility
-      - try-scenarios
-      - floating-deps-tests
+      - default_tests
+      - floating_tests
+      - typecheck
+      - try_scenarios
+
     steps:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - uses: volta-cli/action@v1
-      - name: Cache pnpm modules
-        uses: actions/cache@v3
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-
-      - uses: pnpm/action-setup@v2.2.2
-        with:
-          version: 7.1.2
-      - name: Install Dependencies
-        run: pnpm install
-      - name: Download built package from cache
-        uses: actions/download-artifact@v3
-        with:
-          name: dist
-          path: ${{ env.dist }}
+      - uses: ./.github/actions/pnpm
+      - uses: ./.github/actions/download-built-package
       - name: Release
         run: ./node_modules/.bin/semantic-release
         working-directory: ./ember-browser-services
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+

--- a/ci.yml
+++ b/ci.yml
@@ -38,6 +38,8 @@ support:
    - typescript@4.5
    - typescript@4.6
    - typescript@4.7
+   - typescript@4.8
+   - typescript@4.9
 
 
 release:


### PR DESCRIPTION
- I updated ci.yml
- ran `pnpm ci:update` - uses https://github.com/NullVoxPopuli/ember-ci-update (needs to be updated to support Changesets -- but that's more involved as a bot needs to be added to the repo as well)
- commit
