### PR TITLE
Add reproduction for #413

### DIFF
--- a/test-app/app/instance-initializers/lookup-browser-service.ts
+++ b/test-app/app/instance-initializers/lookup-browser-service.ts
@@ -1,0 +1,13 @@
+import { assert } from '@ember/debug';
+
+import type ApplicationInstance from '@ember/application/instance';
+
+export function initialize(application: ApplicationInstance) {
+  const windowService = application?.lookup('service:browser/window');
+
+  assert('Expected to have the window service', windowService);
+}
+
+export default {
+  initialize,
+};


### PR DESCRIPTION
Reproduces #413. No tests added, existing tests will just blow up with the browser is navigating away form the test suite due to `location.href` not being mocked...