### PR TITLE
Fix broken changeset

### DIFF
--- a/.changeset/twenty-worms-sip.md
+++ b/.changeset/twenty-worms-sip.md
@@ -1,6 +1,5 @@
 ---
 "ember-browser-services": patch
-"test-app": patch
 ---
 
 Unregister services before they are registered in `setupBrowserFakes()` 


### PR DESCRIPTION
Fix wrong changeset, [failing to create a release](https://github.com/CrowdStrike/ember-browser-services/actions/runs/11392294260/job/31698175475). This was done in the UI with the changeset app, not sure why it defaulted to include `test-app` which later caused the failue.